### PR TITLE
Python 3.9 wants newer pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django==3.2.7
-Pillow==7.1.1
+Pillow==9.0.1


### PR DESCRIPTION
Currently we use Pillow 7.1.1 which [doesn't work with Python 3.9](https://pillow.readthedocs.io/en/latest/installation.html#python-support).
